### PR TITLE
Add new NAND ID, Fix USBD panic issue

### DIFF
--- a/drivers/mtd/nand/nand_ids.c
+++ b/drivers/mtd/nand/nand_ids.c
@@ -48,6 +48,9 @@ struct nand_flash_dev nand_flash_ids[] = {
 	{"TC58NVG6D2 64G 3.3V 8-bit",
 		{ .id = {0x98, 0xde, 0x94, 0x82, 0x76, 0x56, 0x04, 0x20} },
 		  SZ_8K, SZ_8K, SZ_2M, 0, 8, 640},
+	{"MT29F32G08ABAAA 32G 3.3V 8-bit",
+		{ .id = {0x2C, 0x68, 0x00, 0x27, 0xA9} },
+		  SZ_8K, SZ_4K, SZ_1M, 0, 5, 448},
 
 	LEGACY_ID_NAND("NAND 4MiB 5V 8-bit",   0x6B, 4, SZ_8K, SP_OPTIONS),
 	LEGACY_ID_NAND("NAND 4MiB 3,3V 8-bit", 0xE3, 4, SZ_8K, SP_OPTIONS),

--- a/drivers/usb/gadget/nuc970_udc.c
+++ b/drivers/usb/gadget/nuc970_udc.c
@@ -77,7 +77,7 @@ static u32 udc_transfer(struct nuc970_ep *ep, u8* buf, size_t size, u32 mode);
 static void nuc970_udc_enable(struct nuc970_udc *dev);
 static void nuc970_udc_disable(struct nuc970_udc *dev);
 
-
+//#define pr_devel printk
 
 static void nuke (struct nuc970_udc *udc, struct nuc970_ep *ep)
 {
@@ -220,6 +220,7 @@ write_packet(struct nuc970_ep *ep, struct nuc970_request *req)
 					printk("unplug!\n");
 					return 0;
 				}
+				//msleep(1);
 			}
 			tmp = len / 4;
 			for (i=0; i<tmp; i++)
@@ -532,7 +533,7 @@ void paser_irq_nep(int irq, struct nuc970_ep *ep, u32 IrqSt)
 
 	if (list_empty(&ep->queue))
 	{
-		pr_devel("nep->queue is empty\n");
+		//pr_devel("nep->queue is empty\n");
 		req = 0;
 	}
 	else
@@ -568,6 +569,7 @@ void paser_irq_nep(int irq, struct nuc970_ep *ep, u32 IrqSt)
 					printk("unplug!\n");
 					break;
 				}
+				//msleep(1);
 			}
 			if (dev->usb_dma_trigger)
 			{
@@ -579,6 +581,7 @@ void paser_irq_nep(int irq, struct nuc970_ep *ep, u32 IrqSt)
 						printk("unplug!\n");
 						break;
 					}
+					//msleep(1);
 				}
 				__raw_writel(0x20, controller.reg + REG_USBD_IRQ_STAT);
 				udc_isr_dma(dev);
@@ -658,6 +661,7 @@ void paser_irq_nep(int irq, struct nuc970_ep *ep, u32 IrqSt)
 					printk("unplug!\n");
 					break;
 				}
+				//msleep(1);
 			}
 			fifo_count = __raw_readl(controller.reg + datacnt_reg);
 
@@ -671,6 +675,7 @@ void paser_irq_nep(int irq, struct nuc970_ep *ep, u32 IrqSt)
 						printk("unplug!\n");
 						break;
 					}
+					//msleep(1);
 				}
 				__raw_writel(0x02, controller.reg + REG_USBD_IRQ_STAT);
 				udc_isr_dma(dev);
@@ -695,7 +700,7 @@ void paser_irq_nepint(int irq, struct nuc970_ep *ep, u32 IrqSt)
 
 	if (list_empty(&ep->queue))
 	{
-		pr_devel("nepirq->queue is empty\n");
+		//pr_devel("nepirq->queue is empty\n");
 		req = 0;
 		return;
 	}
@@ -714,6 +719,7 @@ void paser_irq_nepint(int irq, struct nuc970_ep *ep, u32 IrqSt)
 					printk("unplug!\n");
 					break;
 				}
+				//msleep(1);
 			}
 			if (dev->usb_dma_trigger)
 			{
@@ -725,6 +731,7 @@ void paser_irq_nepint(int irq, struct nuc970_ep *ep, u32 IrqSt)
 						printk("unplug!\n");
 						break;
 					}
+					//msleep(1);
 				}
 				__raw_writel(0x20, controller.reg + REG_USBD_IRQ_STAT);
 				udc_isr_dma(dev);
@@ -1508,7 +1515,7 @@ static void udc_isr_ctrl_pkt(struct nuc970_udc *dev)
 
 	if (list_empty(&ep->queue))
 	{
-		pr_devel("ctrl ep->queue is empty\n");
+		//pr_devel("ctrl ep->queue is empty\n");
 		req = 0;
 	}
 	else
@@ -1736,6 +1743,7 @@ static u32 udc_transfer(struct nuc970_ep *ep, u8* buf, size_t size, u32 mode)
 				printk("unplug!\n");
 				return 0;
 			}
+			//msleep(1);
 		}
 		{
 			dev->usb_dma_dir = Ep_In;


### PR DESCRIPTION
Add new NAND ID which NUC970 can supported
Remove msleep from USBD to avoid kernel panic

Change-Id: Idfd1e9a86951631d1b70c94d4781fbae724c0477